### PR TITLE
SSL is now always true.

### DIFF
--- a/app/views/account/register.html.erb
+++ b/app/views/account/register.html.erb
@@ -26,7 +26,7 @@
   <p><%= custom_field_tag_with_label :user, value %></p>
 <% end %>
 
-<%= recaptcha_tags :public_key => Setting.plugin_recaptcha['recaptcha_public_key'], :ssl => true %>
+<%= recaptcha_tags :public_key => Setting.plugin_recaptcha['recaptcha_public_key'] %>
 </div>
 
 <%= submit_tag l(:button_submit) %>


### PR DESCRIPTION
Recaptcha::RecaptchaError in Account#register raise:
SSL is now always true. Please remove 'ssl' from your calls to recaptcha_tags.
---
Redmine 3.3
Rails 4.2.6
Ruby 2.0.0