### PR TITLE
fix "No private key" error

### DIFF
--- a/app/views/account/register.html.erb
+++ b/app/views/account/register.html.erb
@@ -26,7 +26,7 @@
   <p><%= custom_field_tag_with_label :user, value %></p>
 <% end %>
 
-<%= recaptcha_tags :hl=>current_language, :public_key => Setting.plugin_recaptcha['recaptcha_public_key'] %>
+<%= recaptcha_tags :hl=>current_language, :site_key => Setting.plugin_recaptcha['recaptcha_public_key'] %>
 </div>
 
 <%= submit_tag l(:button_submit) %>

--- a/lib/account_controller_patch.rb
+++ b/lib/account_controller_patch.rb
@@ -27,7 +27,7 @@ module AccountControllerRecaptchaPatch
             unless user_params[:identity_url].present? && user_params[:password].blank? && user_params[:password_confirmation].blank?
               @user.password, @user.password_confirmation = user_params[:password], user_params[:password_confirmation]
             end
-            if verify_recaptcha(:model => @user, :private_key => Setting.plugin_recaptcha['recaptcha_private_key'])
+            if verify_recaptcha(:model => @user, :secret_key => Setting.plugin_recaptcha['recaptcha_private_key'])
               case Setting.self_registration
               when '1'
                 register_by_email_activation(@user)


### PR DESCRIPTION
  upgrading to recaptcha v2 / compatible with recaptcha 4.0.0 gem

Without this I ended up with a blank error page like this one: ("No site key", or "no private key", depending on gem recaptcha version)

```
ActionView::Template::Error (No site key specified.):
    26:   <p><%= custom_field_tag_with_label :user, value %></p>
    27: <% end %>
    28: 
    29: <%= recaptcha_tags :hl=>current_language, :public_key => Setting.plugin_recaptcha['recaptcha_public_key'] %>
    30: </div>
    31: 
    32: <%= submit_tag l(:button_submit) %>
  app/helpers/application_helper.rb:1056:in `labelled_form_for'
```

(no ruby skills here, but it may need a version in Gemfile ?)